### PR TITLE
Removed Crypto++ 5.6.2 required version, patched nvcc build flags, removed enforced -Werror, backported Boost 1.60 patch

### DIFF
--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -3,7 +3,7 @@
 # C++11 check and activation
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
 
-	set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Wno-unknown-pragmas -Wextra -Werror -pedantic -DSHAREDLIB -fPIC ${CMAKE_CXX_FLAGS}")
+	set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Wno-unknown-pragmas -Wextra -pedantic -DSHAREDLIB -fPIC ${CMAKE_CXX_FLAGS}")
 	set(CMAKE_CXX_FLAGS_DEBUG          "-O0 -g -DETH_DEBUG")
 	set(CMAKE_CXX_FLAGS_MINSIZEREL     "-Os -DNDEBUG -DETH_RELEASE")
 	set(CMAKE_CXX_FLAGS_RELEASE        "-O3 -DNDEBUG -DETH_RELEASE")

--- a/cmake/EthDependencies.cmake
+++ b/cmake/EthDependencies.cmake
@@ -41,9 +41,11 @@ message(STATUS "ctest path: ${CTEST_COMMAND}")
 
 # Dependencies must have a version number, to ensure reproducible build. The version provided here is the one that is in the extdep repository. If you use system libraries, version numbers may be different.
 
-find_package (CryptoPP 5.6.2 EXACT REQUIRED)
-message(" - CryptoPP header: ${CRYPTOPP_INCLUDE_DIRS}")
-message(" - CryptoPP lib   : ${CRYPTOPP_LIBRARIES}")
+if (CRYPTOPP_FOUND)
+    # find_package (CryptoPP 5.6.2 REQUIRED)
+    message(" - CryptoPP header: ${CRYPTOPP_INCLUDE_DIRS}")
+    message(" - CryptoPP lib   : ${CRYPTOPP_LIBRARIES}")
+endif()
 
 find_package (LevelDB REQUIRED)
 message(" - LevelDB header: ${LEVELDB_INCLUDE_DIRS}")

--- a/cmake/EthDependencies.cmake
+++ b/cmake/EthDependencies.cmake
@@ -41,11 +41,9 @@ message(STATUS "ctest path: ${CTEST_COMMAND}")
 
 # Dependencies must have a version number, to ensure reproducible build. The version provided here is the one that is in the extdep repository. If you use system libraries, version numbers may be different.
 
-if (CRYPTOPP_FOUND)
-    # find_package (CryptoPP 5.6.2 REQUIRED)
-    message(" - CryptoPP header: ${CRYPTOPP_INCLUDE_DIRS}")
-    message(" - CryptoPP lib   : ${CRYPTOPP_LIBRARIES}")
-endif()
+find_package (CryptoPP 5.6.2 REQUIRED)
+message(" - CryptoPP header: ${CRYPTOPP_INCLUDE_DIRS}")
+message(" - CryptoPP lib   : ${CRYPTOPP_LIBRARIES}")
 
 find_package (LevelDB REQUIRED)
 message(" - LevelDB header: ${LEVELDB_INCLUDE_DIRS}")

--- a/libethash-cuda/CMakeLists.txt
+++ b/libethash-cuda/CMakeLists.txt
@@ -5,7 +5,7 @@ FIND_PACKAGE(CUDA REQUIRED)
 file(GLOB SRC_LIST "*.cpp" "*.cu")
 file(GLOB HEADERS "*.h" "*.cuh")
 
-set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};--std=c++11;--disable-warnings;--ptxas-options=-v;-use_fast_math;-lineinfo)
+set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};--disable-warnings;--ptxas-options=-v;-use_fast_math;-lineinfo)
 
 LIST(APPEND CUDA_NVCC_FLAGS_RELEASE -O3)
 LIST(APPEND CUDA_NVCC_FLAGS_DEBUG -G)

--- a/libethcore/Ethash.cpp
+++ b/libethcore/Ethash.cpp
@@ -111,7 +111,7 @@ void Ethash::BlockHeaderRaw::verifyParent(BlockHeaderRaw const& _parent)
 	if (m_gasLimit < c_minGasLimit ||
 		m_gasLimit <= _parent.m_gasLimit - _parent.m_gasLimit / c_gasLimitBoundDivisor ||
 		m_gasLimit >= _parent.m_gasLimit + _parent.m_gasLimit / c_gasLimitBoundDivisor)
-        BOOST_THROW_EXCEPTION(InvalidGasLimit() << errinfo_min((bigint)_parent.m_gasLimit - _parent.m_gasLimit / c_gasLimitBoundDivisor) << errinfo_got((bigint)m_gasLimit) << errinfo_max((bigint)_parent.m_gasLimit + _parent.m_gasLimit / c_gasLimitBoundDivisor));
+        	BOOST_THROW_EXCEPTION(InvalidGasLimit() << errinfo_min((bigint)(_parent.m_gasLimit - _parent.m_gasLimit / c_gasLimitBoundDivisor)) << errinfo_got((bigint)m_gasLimit) << errinfo_max((bigint)(_parent.m_gasLimit + _parent.m_gasLimit / c_gasLimitBoundDivisor)));
 }
 
 void Ethash::BlockHeaderRaw::populateFromParent(BlockHeaderRaw const& _parent)

--- a/libethcore/Ethash.cpp
+++ b/libethcore/Ethash.cpp
@@ -111,7 +111,7 @@ void Ethash::BlockHeaderRaw::verifyParent(BlockHeaderRaw const& _parent)
 	if (m_gasLimit < c_minGasLimit ||
 		m_gasLimit <= _parent.m_gasLimit - _parent.m_gasLimit / c_gasLimitBoundDivisor ||
 		m_gasLimit >= _parent.m_gasLimit + _parent.m_gasLimit / c_gasLimitBoundDivisor)
-		BOOST_THROW_EXCEPTION(InvalidGasLimit() << errinfo_min((bigint)_parent.m_gasLimit - _parent.m_gasLimit / c_gasLimitBoundDivisor) << errinfo_got((bigint)m_gasLimit) << errinfo_max((bigint)_parent.m_gasLimit + _parent.m_gasLimit / c_gasLimitBoundDivisor));
+        BOOST_THROW_EXCEPTION(InvalidGasLimit() << errinfo_min((bigint)_parent.m_gasLimit - _parent.m_gasLimit / c_gasLimitBoundDivisor) << errinfo_got((bigint)m_gasLimit) << errinfo_max((bigint)_parent.m_gasLimit + _parent.m_gasLimit / c_gasLimitBoundDivisor));
 }
 
 void Ethash::BlockHeaderRaw::populateFromParent(BlockHeaderRaw const& _parent)


### PR DESCRIPTION
All the changes has been tested on an up-to-date Arch Linux system.

- removed Crypto++ 5.6.2 required version, [as reported](https://github.com/Genoil/cpp-ethereum/issues/11#issue-138981098) from @Warudo.
- patched nvcc build flags [as reported](https://github.com/Genoil/cpp-ethereum/issues/7#issuecomment-193256881) from @Warudo
- removed enforced `-Werror`, some warnings can be safely ignored.
- backported Boost 1.60 build fix from [wethree-umbrella](https://github.com/ethereum/webthree-umbrella/issues/108), as reported from @Warudo