### PR TITLE
Fixed --cuda-devices always selecting gpu 0 bug

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -205,8 +205,9 @@ public:
 			{
 				try
 				{
-					m_openclDevices[m_openclDeviceCount++] = stol(argv[++i]);
-				}
+					m_openclDevices[m_openclDeviceCount] = stol(argv[++i]);
+					++m_openclDeviceCount;
+                }
 				catch (...)
 				{
 					i--;
@@ -248,7 +249,8 @@ public:
 			{
 				try
 				{
-					m_cudaDevices[m_cudaDeviceCount++] = stol(argv[++i]);
+					m_cudaDevices[m_cudaDeviceCount] = stol(argv[++i]);
+					++m_cudaDeviceCount;
 				}
 				catch (...)
 				{


### PR DESCRIPTION
When this option was not the last one, it always added device 0 to the selection.
Also did the same changes to --opencl-devices.