### PR TITLE
Fix in README for CUDA builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ git clone https://github.com/Genoil/cpp-ethereum/
 cd cpp-ethereum/
 mkdir build
 cd build
-cmake -DBUNDLE=miner ..
+cmake -DBUNDLE=cudaminer ..
 make -j8
 ```
 


### PR DESCRIPTION
I guess "cudaminer" should be instead of just "miner" when building ethminer with CUDA support.