### PR TITLE
Fix cmake file for libethash-cuda

### DIFF
--- a/libethash-cuda/CMakeLists.txt
+++ b/libethash-cuda/CMakeLists.txt
@@ -5,7 +5,7 @@ FIND_PACKAGE(CUDA REQUIRED)
 file(GLOB SRC_LIST "*.cpp" "*.cu")
 file(GLOB HEADERS "*.h" "*.cuh")
 
-set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};--std=c++11;--disable-warnings;--ptxas-options=-v;-use_fast_math;-lineinfo)
+set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};--disable-warnings;--ptxas-options=-v;-use_fast_math;-lineinfo)
 
 LIST(APPEND CUDA_NVCC_FLAGS_RELEASE -O3)
 LIST(APPEND CUDA_NVCC_FLAGS_DEBUG -G)


### PR DESCRIPTION
The cuda-miner target currently fails on recent nvcc versions due to a duplicate compiler flag `--std=c++11` in the cmake file for libethash-cuda. This PR fixes building by removing it.