### PR TITLE
Use keccak sha3 implementation if cryptopp version >= 5.6.4

### DIFF
--- a/libethash/sha3_cryptopp.cpp
+++ b/libethash/sha3_cryptopp.cpp
@@ -21,17 +21,28 @@
 */
 #include <stdint.h>
 #include <cryptopp/sha3.h>
+#if (CRYPTOPP_VERSION >= 564)
+#include <cryptopp/keccak.h>
+#endif
 
 extern "C" {
 struct ethash_h256;
 typedef struct ethash_h256 ethash_h256_t;
 void SHA3_256(ethash_h256_t const* ret, uint8_t const* data, size_t size)
 {
+#if (CRYPTOPP_VERSION >= 564)
+	CryptoPP::Keccak_256().CalculateDigest((uint8_t*)ret, data, size);
+#else
 	CryptoPP::SHA3_256().CalculateDigest((uint8_t*)ret, data, size);
+#endif
 }
 
 void SHA3_512(uint8_t* const ret, uint8_t const* data, size_t size)
 {
+#if (CRYPTOPP_VERSION >= 564)
+	CryptoPP::Keccak_512().CalculateDigest(ret, data, size);
+#else
 	CryptoPP::SHA3_512().CalculateDigest(ret, data, size);
+#endif
 }
 }


### PR DESCRIPTION
Starting from version 5.6.4 of cryptopp, implementation of sha3 (sha3.h) was changed
to use new padding defined by fips 202 (see weidai11/cryptopp@844daf0).
The old version of sha3 was moved to keccak (keccak.h).
