### PR TITLE
Removed bogus text in apt-get command

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Ubuntu 15.10 or Newer. OpenCL + CUDA (for NVIDIA cards)
 ```bash
 wget http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1404/x86_64/cuda-repo-ubuntu1404_7.5-18_amd64.deb
 sudo dpkg -i cuda-repo-ubuntu1404_7.5-18_amd64.deb
-sudo apt-gethttps://github.com/Genoil/cpp-ethereum/blob/master/README.md -y install software-properties-common
+sudo apt-get -y install software-properties-common
 sudo add-apt-repository -y ppa:ethereum/ethereum
 sudo apt-get update
 sudo apt-get install git cmake libcryptopp-dev libleveldb-dev libjsoncpp-dev libjsonrpccpp-dev libboost-all-dev libgmp-dev libreadline-dev libcurl4-gnutls-dev ocl-icd-libopencl1 opencl-headers mesa-common-dev libmicrohttpd-dev build-essential cuda -y


### PR DESCRIPTION
The following readme link was erroneous listed in the command line: https://github.com/Genoil/cpp-ethereum/blob/master/README.md