### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ sudo apt-get update
 sudo apt-get -y install software-properties-common
 add-apt-repository -y ppa:ethereum/ethereum
 sudo apt-get update
-sudo apt-get install git cmake libcryptopp-dev libleveldb-dev libjsoncpp-dev libjson-rpc-cpp-dev libboost-all-dev libgmp-dev libreadline-dev libcurl4-gnutls-dev ocl-icd-libopencl1 opencl-headers mesa-common-dev libmicrohttpd-dev build-essential -y
+sudo apt-get install git cmake libcryptopp-dev libleveldb-dev libjsoncpp-dev libjsonrpccpp-dev libboost-all-dev libgmp-dev libreadline-dev libcurl4-gnutls-dev ocl-icd-libopencl1 opencl-headers mesa-common-dev libmicrohttpd-dev build-essential -y
 git clone https://github.com/Genoil/cpp-ethereum/
 cd cpp-ethereum/
 mkdir build


### PR DESCRIPTION
One of the Ubuntu dependencies had its name changed somewhat recently, therefore the current commands spit an error when executed on ubuntu. Changed to correct dependency name. libjson-rpc-cpp-dev --> libjsonrpccpp-dev