### PR TITLE
Added missing devcore library to ethcore

### DIFF
--- a/libethcore/CMakeLists.txt
+++ b/libethcore/CMakeLists.txt
@@ -20,6 +20,7 @@ file(GLOB HEADERS "*.h")
 
 add_library(${EXECUTABLE} ${SRC_LIST} ${HEADERS})
 
+target_link_libraries(${EXECUTABLE} devcore)
 target_link_libraries(${EXECUTABLE} ethash)
 
 if (ETHASHCL)


### PR DESCRIPTION
Seems devcore dependency was missing from ethcore. This fixes compilation on OSX which i believe is the problem as reported in #46 and #143