### PR TITLE
Add CUDA to AppVeyor's Cache

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,10 +11,11 @@ configuration:
   - RelWithDebInfo
 cache:
   - C:/.hunter/_Base/Cache -> cmake/Hunter/config.cmake
+  - C:/CUDA -> appveyor.yml
 
 install: |
-  appveyor DownloadFile https://github.com/ethereum/cpp-dependencies/releases/download/cache/CUDA-v8.0-WindowsServer2012.zip
-  7z x CUDA-v8.0-WindowsServer2012.zip -oC:/
+  if not exist C:/CUDA/v8.0/bin/nvcc.exe appveyor DownloadFile https://github.com/ethereum/cpp-dependencies/releases/download/cache/CUDA-v8.0-WindowsServer2012.zip -FileName CUDA-v8.0-WindowsServer2012.zip
+  if exist CUDA-v8.0-WindowsServer2012.zip 7z x CUDA-v8.0-WindowsServer2012.zip -oC:/
   set PATH=%PATH%;C:/CUDA/v8.0/bin
   nvcc -V
 before_build:


### PR DESCRIPTION
Speed up times by taking out the download and extract of CUDA, It's dependent on changes to the appveyor.yml so when/if you need to update the version it can expire the cache